### PR TITLE
Some improviments

### DIFF
--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -56,7 +56,7 @@ You may also find it useful to view the [demo source](https://github.com/<%- git
 
 ### Usage without a module bundler
 ```
-<script src="node_modules/dist/umd/<%- npmModuleName %>/<%- npmModuleName %>.js"></script>
+<script src="node_modules/<%- npmModuleName %>/bundles/<%- npmModuleName %>.umd.js"></script>
 <script>
     // everything is exported <%- moduleGlobal %> namespace
 </script>

--- a/generators/app/templates/_.gitignore
+++ b/generators/app/templates/_.gitignore
@@ -1,5 +1,6 @@
-.idea
+.idea/
 .DS_Store
-node_modules
-coverage
+node_modules/
+coverage/
 npm-debug.log
+dist/

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -2,9 +2,9 @@
   "name": "<%- npmModuleName %>",
   "version": "0.0.0",
   "description": "<%- projectDescription %>",
-  "main": "./dist/umd/<%- npmModuleName %>.js",
-  "module": "./dist/esm/src/index.js",
-  "typings": "./dist/esm/src/index.d.ts",
+  "main": "./bundles/<%- npmModuleName %>.umd.js",
+  "module": "./index.js",
+  "typings": "./index.d.ts",
   "scripts": {
     "start": "concurrently --raw \"webpack-dev-server --open\" \"npm run test:watch\"",
     "build:demo": "webpack -p",
@@ -18,8 +18,9 @@
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "typedoc": "typedoc --options typedoc.json src/*.ts",
     "gh-pages": "git checkout gh-pages && git merge master --no-edit && npm run build:demo && npm run typedoc && git add . && git commit -m 'chore: build demo and docs' && git push && git checkout master",
+    "copyfiles": "cp package.json LICENSE README.md dist/",
     "prerelease": "npm test",
-    "release": "git add package.json && git commit -m 'chore: bump version number' && standard-version --first-release && git push --follow-tags origin master && npm run build:dist && npm publish",
+    "release": "git add package.json && git commit -m 'chore: bump version number' && standard-version --first-release && git push --follow-tags origin master && npm run build:dist && npm run copyfiles && cd dist/ && npm publish",
     "postrelease": "npm run build:clean && npm run gh-pages",
     "commitmsg": "validate-commit-msg"
   },
@@ -86,9 +87,6 @@
   "peerDependencies": {
     "@angular/core": "^2.0.0"
   },
-  "files": [
-    "dist"
-  ],
   "config": {
     "commitizen": {
       "path": "node_modules/cz-conventional-changelog"

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -20,7 +20,9 @@
     "gh-pages": "git checkout gh-pages && git merge master --no-edit && npm run build:demo && npm run typedoc && git add . && git commit -m 'chore: build demo and docs' && git push && git checkout master",
     "copyfiles": "cp package.json LICENSE README.md dist/",
     "prerelease": "npm test",
-    "release": "git add package.json && git commit -m 'chore: bump version number' && standard-version --first-release && git push --follow-tags origin master && npm run build:dist && npm run copyfiles && cd dist/ && npm publish",
+    "release:git": "git add package.json && git commit -m 'chore: bump version number' && standard-version --first-release && git push --follow-tags origin master",
+    "release:npm": "npm run build:dist && npm run copyfiles && cd dist/;npm publish",
+    "release":"npm run release:git && npm run release:npm",
     "postrelease": "npm run build:clean && npm run gh-pages",
     "commitmsg": "validate-commit-msg"
   },

--- a/generators/app/templates/tsconfig-ngc.json
+++ b/generators/app/templates/tsconfig-ngc.json
@@ -5,10 +5,9 @@
     "moduleResolution": "node",
     "declaration": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
+    "baseUrl": "",
     "stripInternal": true,
-    "outDir": "./dist/esm",
-    "rootDir": "./",
+    "outDir": "./dist",
     "sourceMap": true,
     "inlineSources": true,
     "types": [],
@@ -19,7 +18,7 @@
   ],
   "angularCompilerOptions": {
     "strictMetadataEmit": true,
-    "genDir": "./dist/esm",
+    "genDir": "./dist/",
     "skipTemplateCodegen": true,
     "debug": true
   }

--- a/generators/app/templates/webpack.config.umd.js
+++ b/generators/app/templates/webpack.config.umd.js
@@ -1,10 +1,20 @@
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
-  entry: './src/index.ts',
+  entry: {
+    '<%- npmModuleName %>.umd': './src/index.ts',
+    '<%- npmModuleName %>.umd.min': './src/index.ts',
+  },
   output: {
-    path: path.join(__dirname, 'dist', 'umd'),
-    filename: './<%- npmModuleName %>.js',
+    path: path.join(__dirname, 'dist', 'bundles'),
+    filename: '[name].js',
+    libraryTarget: 'umd',
+    library: 'angularTest'
+  },
+  output: {
+    path: path.join(__dirname, 'dist', 'bundles'),
+    filename: '[name].js',
     libraryTarget: 'umd',
     library: '<%- moduleGlobal %>'
   },
@@ -33,5 +43,12 @@ module.exports = {
   },
   resolve: {
     extensions: ['', '.ts', '.js']
-  }
+  },
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin({
+      include: /\.min\.js$/,
+      minimize: true,
+      compress: { warnings: false }
+    })
+  ]
 };

--- a/generators/app/utils.js
+++ b/generators/app/utils.js
@@ -1,0 +1,87 @@
+var chalk = require('chalk'),
+    path = require('path'),
+    fs = require('fs');
+
+module.exports = {
+    noConfig: function (name, configs) {
+        return function (values) {
+            return new Promise(function (resolve, reject) {
+                var value = configs[name];
+                resolve(value == null || value == undefined);
+            })
+        }
+
+    },
+    configInfo: function (config) {
+        console.info("Using Config: " + JSON.stringify(config))
+        console.info("The config is stored in .yo-rc.json and override the prompts")
+        console.info("You can edit then or delete to re-run the generator")
+    },
+    rewrite: function (args) {
+        var me = this;
+        // check if splicable is already in the body text
+        var re = new RegExp(args.splicable.map(function (line) {
+            return '\s*' + me.escapeRegExp(line);
+        }).join('\n'));
+
+        if (re.test(args.haystack)) {
+            return args.haystack;
+        }
+        var lines = args.haystack.split('\n');
+
+        var otherwiseLineIndex = -1;
+        lines.forEach(function (line, i) {
+            if (line.indexOf(args.needle) !== -1) {
+                otherwiseLineIndex = i;
+            }
+        });
+        var spaces = 0;
+        while (lines[otherwiseLineIndex].charAt(spaces) === ' ') {
+            spaces += 1;
+        }
+
+        var spaceStr = '';
+        while ((spaces -= 1) >= 0) {
+            spaceStr += ' ';
+        }
+        lines.splice(otherwiseLineIndex, 0, args.splicable.map(function (line) {
+            return spaceStr + line;
+        }).join('\n'));
+        return lines.join('\n');
+    },
+    rewriteFile: function (args, _this) {
+        args.path = args.path || process.cwd();
+        var fullPath = path.join(args.path, args.file);
+
+        args.haystack = fs.readFileSync(fullPath).toString();
+
+        var body = this.rewrite(args);
+
+        fs.writeFileSync(fullPath, body);
+    },
+    escapeRegExp: function (str) {
+        return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+    },
+    addGradleDependency: function (scope, group, name, version) {
+        var dependency;
+        if(typeof version === 'undefined') {
+            dependency = `${scope} '${group}:${name}'`
+        }else{
+           dependency = `${scope} '${group}:${name}:${version}'` 
+        }
+        try {
+            var fullPath = 'server/build.gradle';
+            this.rewriteFile({
+                file: fullPath,
+                needle: 'generator-needle-gradle-dependency',
+                splicable: [
+                    dependency
+                ]
+            }, this);
+        } catch (e) {
+            console.error(e);
+            console.log(chalk.yellow('\nUnable to find ') + fullPath + chalk.yellow(' or missing required generator-needle-gradle-dependency. Reference to ') + scope + ': ' + group + ':' + name + ':' + version + chalk.yellow(' not added.\n'));
+        }
+    }
+
+}


### PR DESCRIPTION
### Bundles
The bundle follow the same pattern as other angular modules (@angular/common, @angular/compiler, @angular/core, etc...). Files are on directory **bundles**: 

* bundles/project.umd.js
* bundles/project.umd.min.js

Created a minified version of the bundle.

### Distribution

The distribution follow a flat dir structure. That way the library consumer will see the library as if the _src_ directory is the root of the library, making more nice and intuitive imports when the library is modular. Example:

     import {AuthModule} from 'my-library/auth'
     import {CoreModule} from 'my-library/core'

Instead of:

    import {AuthModule} from 'my-library/dist/esm/src/auth'
    import {CoreModule} from 'my-library/dist/esm/src/core'

Using just _index.ts_ forces webpack and typescript to import all library. Example:

    import {AuthModule, CoreModule} from 'my-library'

Could import all my-library. I'm not sure because of tree-shaking, but changing to flat dir and modular import, will produce a small size final bundle even without three-shaking.

Note: Is necessary to do a `npm publish` from the **dist** directory. This is why the **copyfiles** script is created. If the developer forget that making a manual `npm publish`, it will publish all files.

### Prompt

If someone run the generator twice, the answers will be saved. For example, if someone updates the files from a new release of the generator, the person doesn't need to remember the previous answers.

### Ignore dist folder

The **dist/** folder is just noise for the library author, and make git clones slow. It should be generated

### Separate scripts for git and npm release

Just more convenient. I get myself in the situation that git fails in the middle (for example no upstream origin remote) and I want to make the npm release anyway, without creating a dumb commit.
