### PR TITLE
fix(package.json): gh-pages merge is --no-ff

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -17,7 +17,7 @@
     "commit": "git-cz",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "compodoc": "compodoc -p tsconfig-compodoc.json -d docs -b /<%- githubRepoName %>/docs/ --disableGraph --disableCoverage",
-    "gh-pages": "git checkout gh-pages && git merge master --no-edit && npm run build:demo && npm run compodoc && git add . && git commit -m 'chore: build demo and docs' && git push && git checkout master",
+    "gh-pages": "git checkout gh-pages && git merge master --no-edit --no-ff && npm run build:demo && npm run compodoc && git add . && git commit -m 'chore: build demo and docs' && git push && git checkout master",
     "copyfiles": "cp package.json LICENSE README.md CHANGELOG.md dist/",
     "prerelease": "npm test",
     "release:git": "git add package.json && git commit -m 'chore: bump version number' && standard-version --first-release && git push --follow-tags origin master",


### PR DESCRIPTION
Fix conflict with some .gitconfig
gh-pages merge are always no-fast-foward

---

My .gitconfig (only the important parts) for reference

```
[merge]
    ff = only
[pull]
  rebase = true
[branch]
  autosetuprebase = always
[branch "master"]
  rebase = true
[branch "develop"]
  rebase = true
```